### PR TITLE
CIPENH-58 STC-ANSIBLE : Support for Creating Streamblock with multipl…

### DIFF
--- a/module_utils/xpath.py
+++ b/module_utils/xpath.py
@@ -202,6 +202,8 @@ class NodeSelector:
                 if n not in self.nodes:
                     self.nodes.append(n)
 
+    #requires the duplicate like: 
+    #ipv4netwokblock1 ipv4netwokblock2 ipv4netwokblock1 ipv4netwokblock2
     def extendex(self, other):
         if other != None:
             for n in other.nodes:

--- a/module_utils/xpath.py
+++ b/module_utils/xpath.py
@@ -35,10 +35,17 @@ class Linker:
         return selection.firstNode()
 
     def resolveObjects(self, ref, current=None):
-        selection = self._resolve(ref, current)
-        if selection == None or selection.count() == 0:
+        myrefs = re.split(",|;", ref)
+        myselections = NodeSelector()
+        for myref in myrefs:
+            if myref.strip() == "":
+                continue
+            selection = self._resolve(myref, current)
+            if selection != None and selection.count() > 0:
+                myselections.extendex(selection)
+        if myselections.count() == 0:
             return None
-        return selection
+        return myselections
 
     def _resolve(self, ref, current=None):
         if ref == None:
@@ -195,6 +202,11 @@ class NodeSelector:
                 if n not in self.nodes:
                     self.nodes.append(n)
 
+    def extendex(self, other):
+        if other != None:
+            for n in other.nodes:
+                self.nodes.append(n)
+                
     def intersect(self, other):
         new = NodeSelector()
         if other != None:

--- a/module_utils/xpath_test.py
+++ b/module_utils/xpath_test.py
@@ -321,3 +321,9 @@ class TestLinker:
         linker = Linker(self.createModel())
         with pytest.raises(Exception):
             assert linker._resolve("/port/emulateddevice[@name *= 'dev']'/ipv4if")
+
+    def test11(self):
+        # mulitple refs
+        linker = Linker(self.createModel())
+        nodes = linker.resolveObjects("ref:/port/emulateddevice[*]/ipv4if,ref:/port/emulateddevice[*]/ipv4if")
+        assert nodes.count() == 6

--- a/playbooks/stream-results-repeat.yaml
+++ b/playbooks/stream-results-repeat.yaml
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# @Author: rjezequel
+# @Date:   2019-12-20 09:18:14
+# @Last Modified by:   ronanjs
+# @Last Modified time: 2020-01-13 15:45:28
+
+- 
+  name: shell output
+  register: myshell
+  shell: >
+    {%- for x in range(1, 10) -%}
+        echo -n "abc"
+    {%- endfor -%}
+ 
+- 
+  debug:
+    var: myshell
+
+- 
+  name: Create session
+  stc: 
+    action: session
+    user: "{{ myshell.stdout }}"
+    name: stream_results_repeat
+    chassis: "{{ hostvars[inventory_hostname].chassis }}"
+
+- 
+  name: Create 2 base ports
+  stc: 
+    action: create
+    count: 2
+    objects: 
+      - project: 
+          - port: 
+              location: "//${chassis[item]}/1/1"
+              name: "port-$item"
+
+
+-
+  name: create one Emulated Device under port 1
+  stc: 
+    action: perform
+    command: DeviceCreate
+    properties: 
+      ParentList:  ref:/project
+      CreateCount: 1
+      DeviceCount: 1
+      Port: ref:/port[@Name='port-0']
+      IfStack: Ipv4If EthIIIf
+      IfCount: 1 1
+      name: "device-0"
+
+-
+  name: create one Emulated Device under and 2
+  stc: 
+    action: perform
+    command: DeviceCreate
+    properties: 
+      ParentList:  ref:/project
+      CreateCount: 1
+      DeviceCount: 1
+      Port: ref:/port[@Name='port-1']
+      IfStack: Ipv4If EthIIIf
+      IfCount: 1 1
+      name: "device-1"
+
+- 
+  name: Create a stream block
+  stc: 
+    action: create
+    under: ref:/project
+    objects: 
+    - streamblock: 
+        TrafficPattern: PAIR
+        EnableBidirectionalTraffic: True
+        EnableStreamOnlyGeneration: true
+        SrcBinding-targets: |-
+          {%- for x in range(0, 9) -%}
+          ref:/EmulatedDevice[0]/Ipv4If,
+          {%- endfor -%}
+        DstBinding-targets: |-
+          {%- for x in range(1, 10) -%}
+          ref:/EmulatedDevice[1]/Ipv4If,
+          {%- endfor -%}
+        AffiliationStreamBlockLoadProfile:
+          Load: 10
+
+-
+  name: Take the ports online
+  stc: 
+    action: perform
+    command: AttachPorts
+    properties:
+      RevokeOwner: true
+      PortList: ref:/port
+
+-
+  name: subscribe to streamblock results
+  register: results
+  stc: 
+    action: perform
+    command: SubscribeResultsView
+    properties: 
+      ExecuteSynchronous: true
+      TemplateUri: /Result Views/Stream Results/Stream Block Results.xml
+
+
+-
+  name: Get the stream block result object
+  register: results
+  stc: 
+    action: get
+    objects: ref:/port/StreamBlock
+
+
+
+-
+  name: Get the stream block result object
+  register: results
+  stc: 
+    action: get
+    objects: ref:/port/StreamBlock/TxStreamBlockResults
+
+
+-
+  name: Take the ports offline
+  stc: 
+    action: perform
+    command: DetachPortsCommand
+    properties:
+      PortList: ref:/port
+


### PR DESCRIPTION
CIPENH-58 STC-ANSIBLE : Support for Creating Streamblock with multiple Source and Destination handles
To support jinjia2 code in playbook yaml file as below:
        DstBinding-targets:  |-
          {%- for x in range(0, 10) -%}
          ref:/Port[1]/EmulatedDevice/BgpRouterConfig/BgpIpv4RouteConfig/Ipv4NetworkBlock,
          {%- endfor -%}
